### PR TITLE
change setupDimensions to convert 'margin' into an object

### DIFF
--- a/dist/angularjs-nvd3-directives.js
+++ b/dist/angularjs-nvd3-directives.js
@@ -1,4 +1,4 @@
-/*! angularjs-nvd3-directives - v0.0.0 - 2013-10-10
+/*! angularjs-nvd3-directives - v0.0.1-beta - 2013-10-22
 * http://cmaurer.github.io/angularjs-nvd3-directives
 * Copyright (c) 2013 Christian Maurer; Licensed Apache License, v2.0 */
 angular.module('legendDirectives', [])
@@ -547,6 +547,10 @@ function configureY2axis(chart, scope, attrs){
 function setupDimensions(scope, attrs, element) {
     'use strict';
     var margin = (scope.$eval(attrs.margin) || {left: 50, top: 50, bottom: 50, right: 50});
+    if (typeof(margin) !== "object") {
+        // we were passed a vanilla int, convert to full margin object
+        margin = {left: margin, top: margin, bottom: margin, right: margin};
+    }    
     scope.width = (attrs.width  === "undefined" ? ((element[0].parentElement.offsetWidth) - (margin.left + margin.right)) : (+attrs.width - (margin.left + margin.right)));
     scope.height = (attrs.height === "undefined" ? ((element[0].parentElement.offsetHeight) - (margin.top + margin.bottom)) : (+attrs.height - (margin.top + margin.bottom)));
     return margin;

--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -4,6 +4,10 @@
 function setupDimensions(scope, attrs, element) {
     'use strict';
     var margin = (scope.$eval(attrs.margin) || {left: 50, top: 50, bottom: 50, right: 50});
+    if (typeof(margin) !== "object") {
+        // we were passed a vanilla int, convert to full margin object
+        margin = {left: margin, top: margin, bottom: margin, right: margin};
+    }    
     scope.width = (attrs.width  === "undefined" ? ((element[0].parentElement.offsetWidth) - (margin.left + margin.right)) : (+attrs.width - (margin.left + margin.right)));
     scope.height = (attrs.height === "undefined" ? ((element[0].parentElement.offsetHeight) - (margin.top + margin.bottom)) : (+attrs.height - (margin.top + margin.bottom)));
     return margin;


### PR DESCRIPTION
Hello, when setting the 'margin' attribute in a directive, like:

``` html
          <nvd3-stacked-area-chart
            ...
            margin="50"
          </nvd3-stacked-area-chart>
```

I would see lots of errors in my console for:
Error: Invalid value for <svg> attribute width=“NaN”
Error: Invalid value for <svg> attribute height=“NaN”

I traced this to the width/height margin calculation when margin was set to a simple value. This patch will convert it into a proper margin object and fix those errors.
