### PR TITLE
Allow usage of directives as element attributes

### DIFF
--- a/dist/angularjs-nvd3-directives.js
+++ b/dist/angularjs-nvd3-directives.js
@@ -4,7 +4,7 @@
 angular.module('legendDirectives', [])
     .directive('simpleSvgLegend', function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 id: '@',
                 width: '@',
@@ -594,7 +594,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3LineChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -733,7 +733,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3CumulativeLineChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -875,7 +875,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3StackedAreaChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1059,7 +1059,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3MultiBarChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1188,7 +1188,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3DiscreteBarChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1317,7 +1317,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3HistoricalBarChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1448,7 +1448,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3MultiBarHorizontalChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1577,7 +1577,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3PieChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1665,7 +1665,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3ScatterChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1841,7 +1841,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3ScatterPlusLineChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1911,7 +1911,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3LinePlusBarChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -2053,7 +2053,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3LineWithFocusChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -2209,7 +2209,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3BulletChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -2283,7 +2283,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3SparklineChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -2376,7 +2376,7 @@ angular.module('nvd3ChartDirectives', [])
          * 5) the highest value.
          */
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',

--- a/src/directives/legendDirectives.js
+++ b/src/directives/legendDirectives.js
@@ -1,7 +1,7 @@
 angular.module('legendDirectives', [])
     .directive('simpleSvgLegend', function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 id: '@',
                 width: '@',

--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -52,7 +52,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3LineChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -196,7 +196,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3CumulativeLineChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -343,7 +343,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3StackedAreaChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -532,7 +532,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3MultiBarChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -666,7 +666,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3DiscreteBarChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -800,7 +800,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3HistoricalBarChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -936,7 +936,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3MultiBarHorizontalChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1070,7 +1070,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3PieChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1163,7 +1163,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3ScatterChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1344,7 +1344,7 @@ angular.module('nvd3ChartDirectives', [])
     }])
     .directive('nvd3ScatterPlusLineChart', [function(){
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1419,7 +1419,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3LinePlusBarChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1566,7 +1566,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3LineWithFocusChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1727,7 +1727,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3BulletChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1806,7 +1806,7 @@ angular.module('nvd3ChartDirectives', [])
     .directive('nvd3SparklineChart', [function(){
         'use strict';
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',
@@ -1904,7 +1904,7 @@ angular.module('nvd3ChartDirectives', [])
          * 5) the highest value.
          */
         return {
-            restrict: 'E',
+            restrict: 'EA',
             scope: {
                 data: '=',
                 width: '@',


### PR DESCRIPTION
The Chrome inspector (for example) does not handle unrecognized HTML
elements well.

Where one would expect the directive elements to expand and encompass
child elements (children being the svg element), the inspector shows
a height and width of NaN and the elements appear to be collapsed
when inspecting them.

To make it easier to see how the directive elements are affecting the page
flow, this pull request enables them to be used at attributes.

Thanks for considering! And thanks for making this awesome project. It has
already saved me countless hours.

Cheers,

-Jedidiah

![screen shot 2013-10-30 at 8 48 03 am](https://f.cloud.github.com/assets/862838/1437737/53cc7b6c-4172-11e3-904b-d6d334a318a7.png)
