### PR TITLE
Fix rotate labels

### DIFF
--- a/dist/angularjs-nvd3-directives.js
+++ b/dist/angularjs-nvd3-directives.js
@@ -1,4 +1,4 @@
-/*! angularjs-nvd3-directives - v0.0.2-beta - 2013-10-30
+/*! angularjs-nvd3-directives - v0.0.2-beta - 2013-11-04
 * http://cmaurer.github.io/angularjs-nvd3-directives
 * Copyright (c) 2013 Christian Maurer; Licensed Apache License, v2.0 */
 (function()
@@ -367,8 +367,8 @@
         if(attrs.xaxishighlightzero){
             chart.xAxis.highlightZero((attrs.xaxishighlightzero === "true"));
         }
-        if(attrs.xaxisrotatelables){
-            chart.xAxis.rotateLabels((+attrs.xaxisrotatelables));
+        if(attrs.xaxisrotatelabels){
+            chart.xAxis.rotateLabels((+attrs.xaxisrotatelabels));
         }
     //    if(attrs.xaxisrotateylabel){
     //        chart.xAxis.rotateYLabel((attrs.xaxisrotateylabel === "true"));
@@ -429,8 +429,8 @@
         if(attrs.yaxishighlightzero){
             chart.yAxis.highlightZero((attrs.yaxishighlightzero === "true"));
         }
-        if(attrs.yaxisrotatelables){
-            chart.yAxis.rotateLables(attrs.yaxisrotatelables);
+        if(attrs.yaxisrotatelabels){
+            chart.yAxis.rotateLabels(attrs.yaxisrotatelabels);
         }
         if(attrs.yaxisrotateylabel){
             chart.yAxis.rotateYLabel((attrs.yaxisrotateylabel === "true"));
@@ -485,8 +485,8 @@
         if(attrs.y1axishighlightzero){
             chart.y1Axis.highlightZero((attrs.y1axishighlightzero === "true"));
         }
-        if(attrs.y1axisrotatelables){
-            chart.y1Axis.highlightZero(scope.y1axisrotatelables);
+        if(attrs.y1axisrotatelabels){
+            chart.y1Axis.rotateLabels(scope.y1axisrotatelabels);
         }
         if(attrs.y1axisrotateylabel){
             chart.y1Axis.rotateYLabel((attrs.y1axisrotateylabel === "true"));
@@ -541,8 +541,8 @@
         if(attrs.y2axishighlightzero){
             chart.y2Axis.highlightZero((attrs.y2axishighlightzero === "true"));
         }
-        if(attrs.y2axisrotatelables){
-            chart.y2Axis.highlightZero(scope.y2axisrotatelables);
+        if(attrs.y2axisrotatelabels){
+            chart.y2Axis.rotateLabels(scope.y2axisrotatelabels);
         }
         if(attrs.y2axisrotateylabel){
             chart.y2Axis.rotateYLabel((attrs.y2axisrotateylabel === "true"));
@@ -688,7 +688,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -708,7 +708,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -824,7 +824,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -844,7 +844,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -968,7 +968,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -988,7 +988,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1135,7 +1135,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1155,7 +1155,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1257,7 +1257,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1277,7 +1277,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1387,7 +1387,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1407,7 +1407,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1513,7 +1513,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1533,7 +1533,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1738,7 +1738,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1758,7 +1758,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1955,7 +1955,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1975,7 +1975,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1995,7 +1995,7 @@ function initializeMargin(scope, attrs){
                     y2axisrangebands: '&',
                     y2axisshowmaxmin: '@',
                     y2axishighlightzero: '@',
-                    y2axisrotatelables: '@',
+                    y2axisrotatelabels: '@',
                     y2axisrotateylabel: '@',
                     y2axisstaggerlabels: '@',
 
@@ -2094,7 +2094,7 @@ function initializeMargin(scope, attrs){
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -2114,7 +2114,7 @@ function initializeMargin(scope, attrs){
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -2134,7 +2134,7 @@ function initializeMargin(scope, attrs){
                     y2axisrangebands: '&',
                     y2axisshowmaxmin: '@',
                     y2axishighlightzero: '@',
-                    y2axisrotatelables: '@',
+                    y2axisrotatelabels: '@',
                     y2axisrotateylabel: '@',
                     y2axisstaggerlabels: '@',
 

--- a/src/directives/nvD3AxisConfiguration.js
+++ b/src/directives/nvD3AxisConfiguration.js
@@ -49,8 +49,8 @@
         if(attrs.xaxishighlightzero){
             chart.xAxis.highlightZero((attrs.xaxishighlightzero === "true"));
         }
-        if(attrs.xaxisrotatelables){
-            chart.xAxis.rotateLabels((+attrs.xaxisrotatelables));
+        if(attrs.xaxisrotatelabels){
+            chart.xAxis.rotateLabels((+attrs.xaxisrotatelabels));
         }
     //    if(attrs.xaxisrotateylabel){
     //        chart.xAxis.rotateYLabel((attrs.xaxisrotateylabel === "true"));
@@ -111,8 +111,8 @@
         if(attrs.yaxishighlightzero){
             chart.yAxis.highlightZero((attrs.yaxishighlightzero === "true"));
         }
-        if(attrs.yaxisrotatelables){
-            chart.yAxis.rotateLables(attrs.yaxisrotatelables);
+        if(attrs.yaxisrotatelabels){
+            chart.yAxis.rotateLabels(attrs.yaxisrotatelabels);
         }
         if(attrs.yaxisrotateylabel){
             chart.yAxis.rotateYLabel((attrs.yaxisrotateylabel === "true"));
@@ -167,8 +167,8 @@
         if(attrs.y1axishighlightzero){
             chart.y1Axis.highlightZero((attrs.y1axishighlightzero === "true"));
         }
-        if(attrs.y1axisrotatelables){
-            chart.y1Axis.highlightZero(scope.y1axisrotatelables);
+        if(attrs.y1axisrotatelabels){
+            chart.y1Axis.rotateLabels(scope.y1axisrotatelabels);
         }
         if(attrs.y1axisrotateylabel){
             chart.y1Axis.rotateYLabel((attrs.y1axisrotateylabel === "true"));
@@ -223,8 +223,8 @@
         if(attrs.y2axishighlightzero){
             chart.y2Axis.highlightZero((attrs.y2axishighlightzero === "true"));
         }
-        if(attrs.y2axisrotatelables){
-            chart.y2Axis.highlightZero(scope.y2axisrotatelables);
+        if(attrs.y2axisrotatelabels){
+            chart.y2Axis.rotateLabels(scope.y2axisrotatelabels);
         }
         if(attrs.y2axisrotateylabel){
             chart.y2Axis.rotateYLabel((attrs.y2axisrotateylabel === "true"));

--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -140,7 +140,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -160,7 +160,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -276,7 +276,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -296,7 +296,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -420,7 +420,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -440,7 +440,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -587,7 +587,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -607,7 +607,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -709,7 +709,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -729,7 +729,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -839,7 +839,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -859,7 +859,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -965,7 +965,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -985,7 +985,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1190,7 +1190,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1210,7 +1210,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1407,7 +1407,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1427,7 +1427,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1447,7 +1447,7 @@
                     y2axisrangebands: '&',
                     y2axisshowmaxmin: '@',
                     y2axishighlightzero: '@',
-                    y2axisrotatelables: '@',
+                    y2axisrotatelabels: '@',
                     y2axisrotateylabel: '@',
                     y2axisstaggerlabels: '@',
 
@@ -1546,7 +1546,7 @@
                     xaxisrangebands: '&',
                     xaxisshowmaxmin: '@',
                     xaxishighlightzero: '@',
-                    xaxisrotatelables: '@',
+                    xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
 
@@ -1566,7 +1566,7 @@
                     yaxisrangebands: '&',
                     yaxisshowmaxmin: '@',
                     yaxishighlightzero: '@',
-                    yaxisrotatelables: '@',
+                    yaxisrotatelabels: '@',
                     yaxisrotateylabel: '@',
                     yaxisstaggerlabels: '@',
 
@@ -1586,7 +1586,7 @@
                     y2axisrangebands: '&',
                     y2axisshowmaxmin: '@',
                     y2axishighlightzero: '@',
-                    y2axisrotatelables: '@',
+                    y2axisrotatelabels: '@',
                     y2axisrotateylabel: '@',
                     y2axisstaggerlabels: '@',
 


### PR DESCRIPTION
nvd3-discrete-bar-chart's xAxisRotateLabels was being ignored without error. Investigation uncovered a few incorrect function calls to highlightZero instead of rotateLabels.

Fixed:
- call rotateLabels rather than highlightZero in some cases
- spelling corrections (rotateLables -> rotateLabels)
