### PR TITLE
add missing show X/Y axis option for area and bar charts

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -396,6 +396,7 @@
                     sizeDomain: '&',
 
                     //xaxis
+                    showxaxis: '&',
                     xaxisorient: '&',
                     xaxisticks: '&',
                     xaxistickvalues: '&xaxistickvalues',
@@ -416,6 +417,7 @@
                     xaxisstaggerlabels: '@',
 
                     //yaxis
+                    showyaxis: '&',
                     yaxisorient: '&',
                     yaxisticks: '&',
                     yaxistickvalues: '&yaxistickvalues',
@@ -469,6 +471,8 @@
                                         .forceSize(attrs.forcesize === undefined ? [] : scope.$eval(attrs.forcesize)) // List of numbers to Force into the Size scale
                                         .showLegend(attrs.showlegend === undefined ? false : (attrs.showlegend === "true"))
                                         .showControls(attrs.showcontrols === undefined ? false : (attrs.showcontrols === "true"))
+                                        .showXAxis(attrs.showxaxis === undefined ? false : (attrs.showxaxis  === "true"))
+                                        .showYAxis(attrs.showyaxis === undefined ? false : (attrs.showyaxis  === "true"))
                                         .tooltips(attrs.tooltips === undefined ? false : (attrs.tooltips  === "true"))
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .interactive(attrs.interactive === undefined ? false : (attrs.interactive === "true"))
@@ -563,6 +567,7 @@
                     stacked: '@',
 
                     //xaxis
+                    showxaxis: '&',
                     xaxisorient: '&',
                     xaxisticks: '&',
                     xaxistickvalues: '&xaxistickvalues',
@@ -583,6 +588,7 @@
                     xaxisstaggerlabels: '@',
 
                     //yaxis
+                    showyaxis: '&',
                     yaxisorient: '&',
                     yaxisticks: '&',
                     yaxistickvalues: '&yaxistickvalues',
@@ -633,6 +639,8 @@
                                         .forceY(attrs.forcey === undefined ? [0] : scope.$eval(attrs.forcey)) // List of numbers to Force into the Y scale
                                         .showLegend(attrs.showlegend === undefined ? false : (attrs.showlegend === "true"))
                                         .showControls(attrs.showcontrols === undefined ? false : (attrs.showcontrols === "true"))
+                                        .showXAxis(attrs.showxaxis === undefined ? false : (attrs.showxaxis  === "true"))
+                                        .showYAxis(attrs.showyaxis === undefined ? false : (attrs.showyaxis  === "true"))
                                         .tooltips(attrs.tooltips === undefined ? false : (attrs.tooltips  === "true"))
                                         .reduceXTicks(attrs.reducexticks === undefined ? false: (attrs.reducexticks === "true"))
                                         .staggerLabels(attrs.staggerlabels === undefined ? false : (attrs.staggerlabels === "true"))


### PR DESCRIPTION
Hi, I wanted to hide some axes on my charts, but it seems that for some classes those variables were not checked.

This fixes the problem.
