### PR TITLE
fixed incorrect yaxis config for line-with-focus-chart

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -1808,7 +1808,7 @@
 
                                     configureXaxis(chart, scope, attrs);
                                     configureX2axis(chart, scope, attrs);
-                                    configureY1axis(chart, scope, attrs);
+                                    configureYaxis(chart, scope, attrs);
                                     configureY2axis(chart, scope, attrs);
                                     configureLegend(chart, scope, attrs);
                                     processEvents(chart, scope);


### PR DESCRIPTION
yaxis attributes were not being configured. The directive was running axis config on y1 and not y.
