### PR TITLE
Move example deps into devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,9 @@
   "dependencies": {
     "angular": "~1.2.4",
     "d3": "~3.4.1",
-    "nvd3": "~v1.1.15-beta",
+    "nvd3": "~v1.1.15-beta"
+  },
+  "devDependencies": {
     "moment": "~2.5.0",
     "angular-route": "~1.2.13"
   }


### PR DESCRIPTION
As far as I can tell, `angularjs-nvd3-directives` doesn't depend on `moment` or
`angular-route` directly; rather they're only used in the examples.

Build tools such as `grunt-bower-install` will inject each dependency's `main`
properties into `index.html`, which in our case, is unnecessarily including
`moment`.
