### PR TITLE
Tooltip content function and size-related functions for scatter plots

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -1253,7 +1253,7 @@
                 }
             };
         }])
-        .directive('nvd3ScatterChart', ['$filter', '$parse', function($filter, $parse){
+        .directive('nvd3ScatterChart', ['$filter', function($filter){
             return {
                 restrict: 'EA',
                 scope: {

--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -1253,7 +1253,7 @@
                 }
             };
         }])
-        .directive('nvd3ScatterChart', ['$filter', function($filter){
+        .directive('nvd3ScatterChart', ['$filter', '$parse', function($filter, $parse){
             return {
                 restrict: 'EA',
                 scope: {
@@ -1272,7 +1272,7 @@
                     fisheye: '@',
                     xPadding: '@',
                     yPadding: '@',
-                    tooltipContent: '&',
+                    tooltipcontent: '&',
                     tooltipXContent: '&',
                     tooltipYContent: '&',
                     color: '&',
@@ -1387,9 +1387,11 @@
                                         .forceX(attrs.forcex === undefined ? [] : scope.$eval(attrs.forcex))
                                         .forceY(attrs.forcey === undefined ? [] : scope.$eval(attrs.forcey))
                                         .forceSize(attrs.forcesize === undefined ? [] : scope.$eval(attrs.forcesize))
+                                        .sizeDomain(attrs.sizedomain === undefined ? function ( d ) {return [0,1];} : scope.sizedomain())
+                                        .sizeRange(attrs.sizerange === undefined ? function ( d ) {return [4,16];} : scope.sizerange())
                                         .interactive(attrs.interactive === undefined ? false : (attrs.interactive === 'true'))
                                         .tooltips(attrs.tooltips === undefined ? false : (attrs.tooltips  === 'true'))
-                                        .tooltipContent(attrs.tooltipContent === undefined ? null : scope.tooltipContent())
+                                        .tooltipContent(attrs.tooltipcontent === undefined ? null : scope.tooltipcontent())
                                         .tooltipXContent(attrs.tooltipxcontent === undefined ? function(key, x) { return '<strong>' + x + '</strong>'; } : scope.tooltipXContent())
                                         .tooltipYContent(attrs.tooltipycontent === undefined ? function(key, x, y) { return '<strong>' + y + '</strong>'; } : scope.tooltipYContent())
                                         .showControls(attrs.showcontrols === undefined ? false : (attrs.showcontrols === 'true'))


### PR DESCRIPTION
In a recent project, we needed finer-grained control over dot sizes and create fancy tooltips. I added some wiring from the scope properties to the NVD3-functions.
