### PR TITLE
Rename xAxis Label Distance to correct property name.

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -432,7 +432,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     showyaxis: '&',
                     useinteractiveguideline: '@',
@@ -629,7 +629,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     showyaxis: '&',
                     yaxisorient: '&',
@@ -771,7 +771,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     yaxisorient: '&',
                     yaxisticks: '&',
@@ -913,7 +913,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     yaxisorient: '&',
                     yaxisticks: '&',
@@ -1055,7 +1055,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     yaxisorient: '&',
                     yaxisticks: '&',
@@ -1319,7 +1319,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     yaxisorient: '&',
                     yaxisticks: '&',
@@ -1520,7 +1520,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     yaxisorient: '&',
                     yaxisticks: '&',
@@ -1665,7 +1665,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
                     //yaxis
                     y1axisorient: '&',
                     y1axisticks: '&',
@@ -1850,7 +1850,7 @@
                     xaxisrotatelabels: '@',
                     xaxisrotateylabel: '@',
                     xaxisstaggerlabels: '@',
-                    xaxisaxislabeldistance: '@',
+                    xaxislabeldistance: '@',
 
                     //x2axis
                     x2axisorient: '&',


### PR DESCRIPTION
The property 'xaxislabeldistance' is used in nvD3AxisConfiguration:68
