### PR TITLE
Fix misalignment of line chart ticks with x axis dates

### DIFF
--- a/dist/angularjs-nvd3-directives.js
+++ b/dist/angularjs-nvd3-directives.js
@@ -929,6 +929,7 @@
                   if ( attrs.tooltipcontent ) {
                     chart.tooltipContent( scope.tooltipcontent() );
                   }
+                  chart.lines.xScale(d3.time.scale());
                   scope.d3Call( data, chart );
                   nv.utils.windowResize( chart.update );
                   scope.chart = chart;


### PR DESCRIPTION
When plotting a time series there's a misalignment of plotted line ticks with the x-axis time scale. 
For example take look at the image below. The x-axis are dates, y-axis are prices:
![misaligned values](http://i.imgur.com/lDM8hkD.png?1)
You can see that the tooltip indicates the date to be 20, and the tick is not aligned with x-axis. 
This added line fixes this error for me. So you can see the same graph aligned in the following picture: 
![aligned values](http://i.imgur.com/WAORTn7.png?1)

I don't know how it will behave when plotting non-time series.
