### PR TITLE
getD3Selector cannot return correct data-chartid

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -18,6 +18,7 @@
             //if an id is not supplied, create a random id.
             if (!attrs['data-chartid']) {
                 angular.element(element).attr('data-chartid', 'chartid' + Math.floor(Math.random() * 1000000001));
+                attrs[ 'data-chartid' ] = element.attr('data-chartid');
             }
             return '[data-chartid=' + attrs['data-chartid'] + ']';
         } else {


### PR DESCRIPTION
This is to fix the issue that getD3Selector() always return [data-chartid=undefined].

The fix changed "attrs" in case attrs['data-chartid'] needs to be used later.

A cleaner change would be just changing the return of this function.