### PR TITLE
fix default x & y accessors for pie chart

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -1218,8 +1218,8 @@
                                 generate: function(){
                                     initializeMargin(scope, attrs);
                                     var chart = nv.models.pieChart()
-                                        .x(attrs.x === undefined ? function(d){ return d[0]; } : scope.x())
-                                        .y(attrs.y === undefined ? function(d){ return d[1]; } : scope.y())
+                                        .x(attrs.x === undefined ? function(d){ return d.key; } : scope.x())
+                                        .y(attrs.y === undefined ? function(d){ return d.y; } : scope.y())
                                         .width(scope.width)
                                         .height(scope.height)
                                         .margin(scope.margin)


### PR DESCRIPTION
Default values for pie chart are now taken from attribute 'key' and 'y' of an array of object and not from an array of array.

@cmaurer This fixes the assertion you made in this https://github.com/cmaurer/angularjs-nvd3-directives/issues/69#issuecomment-29664171