### PR TITLE
Mitigate problem with delay undefined for d3 chart (updated per pull request)

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -710,8 +710,9 @@
                                         .staggerLabels(attrs.staggerlabels === undefined ? false : (attrs.staggerlabels === 'true'))
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .rotateLabels(attrs.rotatelabels === undefined ? 0 : attrs.rotatelabels)
-                                        .color(attrs.color === undefined ? nv.utils.defaultColor()  : scope.color()
+                                        .color(attrs.color === undefined ? nv.utils.defaultColor() : scope.color())
                                         .stacked(attrs.stacked === undefined ? false : (attrs.stacked === 'true'));
+                                    // Delay is in the D3 transitions class, not in the selection class. We make an explicit check with this if statement
                                     if(chart.delay){
                                         chart.delay(attrs.delay === undefined ? 1200 : attrs.delay);
                                     }

--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -710,10 +710,11 @@
                                         .staggerLabels(attrs.staggerlabels === undefined ? false : (attrs.staggerlabels === 'true'))
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .rotateLabels(attrs.rotatelabels === undefined ? 0 : attrs.rotatelabels)
-                                        .color(attrs.color === undefined ? nv.utils.defaultColor()  : scope.color())
-                                        .delay(attrs.delay === undefined ? 1200 : attrs.delay)
+                                        .color(attrs.color === undefined ? nv.utils.defaultColor()  : scope.color()
                                         .stacked(attrs.stacked === undefined ? false : (attrs.stacked === 'true'));
-
+                                    if(chart.delay){
+                                        chart.delay(attrs.delay === undefined ? 1200 : attrs.delay);
+                                    }
                                     if(attrs.tooltipcontent){
                                         chart.tooltipContent(scope.tooltipcontent());
                                     }
@@ -2295,7 +2296,7 @@
                         if (data && angular.isDefined(scope.filtername) && angular.isDefined(scope.filtervalue)) {
                             data =  $filter(scope.filtername)(data, scope.filtervalue);
                         }
-                        
+
                         if(data){
                             //if the chart exists on the scope, do not call addGraph again, update data and call the chart.
                             if(scope.chart){


### PR DESCRIPTION
Mitigate problem with delay undefined for d3 chart

Motivation https://github.com/angularjs-nvd3-directives/angularjs-nvd3-directives/issues/210
- D3 Transitions (contain delay) are a subset of all selections
  API https://github.com/mbostock/d3/wiki/Transitions
- Original pull request: https://github.com/angularjs-nvd3-directives/angularjs-nvd3-directives/pull/329
