### PR TITLE
Update to use v3.5.x of d3 and v1.7.x of nvd3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,8 @@
   ],
   "dependencies": {
     "angular": "~1.2.13",
-    "d3": "~3.3.13",
-    "nvd3": "~v1.1.15-beta"
+    "d3": "~3.5",
+    "nvd3": "~v1.7"
   },
   "devDependencies": {
     "moment": "~2.5.0",

--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -505,8 +505,8 @@
                                         .y(attrs.y === undefined ? function(d){ return d[1]; } : scope.y())
                                         .forceX(attrs.forcex === undefined ? [] : scope.$eval(attrs.forcex)) // List of numbers to Force into the X scale (ie. 0, or a max / min, etc.)
                                         .forceY(attrs.forcey === undefined ? [0] : scope.$eval(attrs.forcey)) // List of numbers to Force into the Y scale
-                                        .size(attrs.size === undefined ? function(d) { return (d.size === undefined ? 1 : d.size); } : scope.size())
-                                        .forceSize(attrs.forcesize === undefined ? [] : scope.$eval(attrs.forcesize)) // List of numbers to Force into the Size scale
+                                        .pointSize(attrs.size === undefined ? function(d) { return (d.size === undefined ? 1 : d.size); } : scope.size())
+                                        .forcePoint(attrs.forcesize === undefined ? [] : scope.$eval(attrs.forcesize)) // List of numbers to Force into the Size scale
                                         .showLegend(attrs.showlegend === undefined ? false : (attrs.showlegend === 'true'))
                                         .showControls(attrs.showcontrols === undefined ? false : (attrs.showcontrols === 'true'))
                                         .showXAxis(attrs.showxaxis === undefined ? false : (attrs.showxaxis  === 'true'))
@@ -1270,13 +1270,9 @@
                     id: '@',
                     showlegend: '@',
                     tooltips: '@',
-                    showcontrols: '@',
                     showDistX: '@',
                     showDistY: '@',
                     rightAlignYAxis: '@',
-                    fisheye: '@',
-                    xPadding: '@',
-                    yPadding: '@',
                     tooltipContent: '&',
                     tooltipXContent: '&',
                     tooltipYContent: '&',
@@ -1285,7 +1281,6 @@
                     nodata: '@',
                     transitionDuration: '@',
                     shape: '&',
-                    onlyCircles: '@',
                     interactive: '@',
                     x: '&',
                     y: '&',
@@ -1388,29 +1383,24 @@
                                         .margin(scope.margin)
                                         .x(attrs.x === undefined ? function(d){ return d.x; } : scope.x())
                                         .y(attrs.y === undefined ? function(d){ return d.y; } : scope.y())
-                                        .size(attrs.size === undefined ? function(d){ return (d.size === undefined ? 1 : d.size); }: scope.size())
+                                        .pointSize(attrs.size === undefined ? function(d){ return (d.size === undefined ? 1 : d.size); }: scope.size())
                                         .forceX(attrs.forcex === undefined ? [] : scope.$eval(attrs.forcex))
                                         .forceY(attrs.forcey === undefined ? [] : scope.$eval(attrs.forcey))
-                                        .forceSize(attrs.forcesize === undefined ? [] : scope.$eval(attrs.forcesize))
+                                        .forcePoint(attrs.forcesize === undefined ? [] : scope.$eval(attrs.forcesize))
                                         .interactive(attrs.interactive === undefined ? false : (attrs.interactive === 'true'))
                                         .tooltips(attrs.tooltips === undefined ? false : (attrs.tooltips  === 'true'))
                                         .tooltipContent(attrs.tooltipContent === undefined ? null : scope.tooltipContent())
                                         .tooltipXContent(attrs.tooltipxcontent === undefined ? function(key, x) { return '<strong>' + x + '</strong>'; } : scope.tooltipXContent())
                                         .tooltipYContent(attrs.tooltipycontent === undefined ? function(key, x, y) { return '<strong>' + y + '</strong>'; } : scope.tooltipYContent())
-                                        .showControls(attrs.showcontrols === undefined ? false : (attrs.showcontrols === 'true'))
                                         .showLegend(attrs.showlegend === undefined ? false : (attrs.showlegend === 'true'))
                                         .showDistX(attrs.showdistx === undefined ? false : (attrs.showdistx === 'true'))
                                         .showDistY(attrs.showdisty === undefined ? false : (attrs.showdisty === 'true'))
-                                        .xPadding(attrs.xpadding === undefined ? 0 : (+attrs.xpadding))
-                                        .yPadding(attrs.ypadding === undefined ? 0 : (+attrs.ypadding))
-                                        .fisheye(attrs.fisheye === undefined ? 0 : (+attrs.fisheye))
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .color(attrs.color === undefined ? nv.utils.defaultColor()  : scope.color())
-                                        .transitionDuration(attrs.transitionduration === undefined ? 250 : (+attrs.transitionduration));
+                                        .duration(attrs.transitionduration === undefined ? 250 : (+attrs.transitionduration));
 
                                     if(attrs.shape){
-                                        chart.scatter.onlyCircles(false);
-                                        chart.scatter.shape(attrs.shape === undefined ? function(d) { return d.shape || 'circle'; } : scope.shape());
+                                        chart.scatter.pointShape(attrs.shape === undefined ? function(d) { return d.shape || 'circle'; } : scope.shape());
                                     }
 
     //'pointActive', 'clipVoronoi', 'clipRadius', 'useVoronoi'
@@ -1486,7 +1476,6 @@
                     nodata: '@',
                     transitionDuration: '@',
                     shape: '&',
-                    onlyCircles: '@',
                     interactive: '@',
                     x: '&',
                     y: '&',
@@ -1588,7 +1577,7 @@
                                         .margin(scope.margin)
                                         .x(attrs.x === undefined ? function(d){ return d.x; } : scope.x())
                                         .y(attrs.y === undefined ? function(d){ return d.y; } : scope.y())
-                                        .size(attrs.size === undefined ? function(d){ return (d.size === undefined ? 1 : d.size); }: scope.size())
+                                        .pointSize(attrs.size === undefined ? function(d){ return (d.size === undefined ? 1 : d.size); }: scope.size())
                                         .interactive(attrs.interactive === undefined ? false : (attrs.interactive === 'true'))
                                         .tooltips(attrs.tooltips === undefined ? false : (attrs.tooltips  === 'true'))
                                         .tooltipContent(attrs.tooltipContent === undefined ? null : scope.tooltipContent())
@@ -1601,11 +1590,10 @@
                                         .fisheye(attrs.fisheye === undefined ? 0 : (+attrs.fisheye))
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .color(attrs.color === undefined ? nv.utils.defaultColor()  : scope.color())
-                                        .transitionDuration(attrs.transitionduration === undefined ? 250 : (+attrs.transitionduration));
+                                        .duration(attrs.transitionduration === undefined ? 250 : (+attrs.transitionduration));
 
                                     if(attrs.shape){
-                                        chart.scatter.onlyCircles(false);
-                                        chart.scatter.shape(attrs.shape === undefined ? function(d) { return d.shape || 'circle'; } : scope.shape());
+                                        chart.scatter.pointShape(attrs.shape === undefined ? function(d) { return d.shape || 'circle'; } : scope.shape());
                                     }
 
                                     scope.d3Call(data, chart);
@@ -1989,7 +1977,7 @@
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .color(attrs.color === undefined ? nv.utils.defaultColor()  : scope.color())
                                         .isArea(attrs.isarea === undefined ? function(d) { return d.area; } : function(){ return (attrs.isarea === 'true'); })
-                                        .size(attrs.size === undefined ? function(d){ return (d.size === undefined ? 1 : d.size); }: scope.size())
+                                        .pointSize(attrs.size === undefined ? function(d){ return (d.size === undefined ? 1 : d.size); }: scope.size())
                                         .interactive(attrs.interactive === undefined ? false : (attrs.interactive === 'true'))
                                         .clipEdge(attrs.clipedge === undefined ? false : (attrs.clipedge === 'true'))
                                         .clipVoronoi(attrs.clipvoronoi === undefined ? false : (attrs.clipvoronoi === 'true'))


### PR DESCRIPTION
I'd like to use the latest d3 and nvd3 so have updated its compatibility; however there were some breaking changes made to nvd3.

Changes made:

Updated size to use pointSize
Updated forceSize to use forcePoint
Updated transitionDuration to use duration
Removed showControls, fisheye, xPadding, yPadding and onlyCircles from scatterChart / scatterPlusLineChart

NB: Only tested using a scatter chart.

NB: Did not update scope attribute names as this would be a BREAKING CHANGE (although considering nvd3 performed the breaking change, perhaps we should too...)
