### PR TITLE
Fixing nvd3 links on usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Include the downloaded dependencies in the ```<head>``` section of the html.
 ```html
 <script src="bower_components/angular/angular.js"></script>
 <script src="bower_components/d3/d3.js"></script>
-<script src="bower_components/nvd3/nv.d3.js"></script>
+<script src="bower_components/nvd3/build/nv.d3.js"></script>
 <script src="bower_components/angularjs-nvd3-directives/dist/angularjs-nvd3-directives.js"></script>
-<link rel="stylesheet" href="bower_components/nvd3/nv.d3.css"/>
+<link rel="stylesheet" href="bower_components/nvd3/build/nv.d3.css"/>
 ```
 
 Create a ```<script>``` block for the angular application


### PR DESCRIPTION
Following the steps, I found out that the `nv.d3.js` and `nv.d3.css` now come on a `build` folder instead of directly on the root of `nvd3` folder.

![image](https://cloud.githubusercontent.com/assets/397851/8733817/3f60d30c-2bdc-11e5-8046-820b4c461fca.png)
