### PR TITLE
fixing pie charts for nvd3 1.8.1, and adding support to not set chart dimensions

### DIFF
--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -62,8 +62,12 @@
         if (chart) {
             chart.width(scope.width).height(scope.height);
             var d3Select = getD3Selector(attrs, element);
-            d3.select(d3Select + ' svg')
-                .attr('viewBox', '0 0 ' + scope.width + ' ' + scope.height);
+            if(scope.width !== undefined && scope.height !== undefined) {
+                d3.select(d3Select + ' svg')
+                    .attr('viewBox', '0 0 ' + scope.width + ' ' + scope.height);
+            } else {
+                d3.select(d3Select + ' svg').attr('viewBox', null);
+            }
             nv.utils.windowResize(chart);
             scope.chart.update();
         }
@@ -1224,11 +1228,10 @@
                                     initializeMargin(scope, attrs);
                                     var chart = nv.models.pieChart()
                                         .x(attrs.x === undefined ? function(d){ return d[0]; } : scope.x())
-                                        .y(attrs.y === undefined ? function(d){ return d[1]; } : scope.y());
-                                    if(scope.width !== undefined && scope.height !== undefined) {
-                                        chart.width(scope.width).height(scope.height);
-                                    }
-                                    chart.margin(scope.margin)
+                                        .y(attrs.y === undefined ? function(d){ return d[1]; } : scope.y())
+                                        .width(scope.width)
+                                        .height(scope.height)
+                                        .margin(scope.margin)
                                         .tooltips(attrs.tooltips === undefined ? false : (attrs.tooltips  === 'true'))
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .showLabels(attrs.showlabels === undefined ? false : (attrs.showlabels === 'true'))

--- a/src/directives/nvd3Directives.js
+++ b/src/directives/nvd3Directives.js
@@ -48,9 +48,12 @@
             d3.select(d3Select)
                 .append('svg');
         }
-        d3.select(d3Select + ' svg')
-            .attr('viewBox', '0 0 ' + scope.width + ' ' + scope.height)
-            .datum(data)
+        var svg = d3.select(d3Select + ' svg');
+        
+        if( scope.width !== undefined && scope.height !== undefined ) {
+            svg.attr('viewBox', '0 0 ' + scope.width + ' ' + scope.height);
+        }
+        svg.datum(data)
             .transition().duration((attrs.transitionduration === undefined ? 250 : (+attrs.transitionduration)))
             .call(chart);
     }
@@ -1167,8 +1170,6 @@
                     id: '@',
                     showlabels: '@',
                     showlegend: '@',
-                    donutLabelsOutside: '@',
-                    pieLabelsOutside: '@',
                     labelType: '@',
                     nodata: '@',
                     margin: '&',
@@ -1178,7 +1179,6 @@
                     donut: '@',
                     donutRatio: '@',
                     labelthreshold: '@',
-                    description: '&',
                     tooltips: '@',
                     tooltipcontent: '&',
                     valueFormat: '&',
@@ -1224,21 +1224,19 @@
                                     initializeMargin(scope, attrs);
                                     var chart = nv.models.pieChart()
                                         .x(attrs.x === undefined ? function(d){ return d[0]; } : scope.x())
-                                        .y(attrs.y === undefined ? function(d){ return d[1]; } : scope.y())
-                                        .width(scope.width)
-                                        .height(scope.height)
-                                        .margin(scope.margin)
+                                        .y(attrs.y === undefined ? function(d){ return d[1]; } : scope.y());
+                                    if(scope.width !== undefined && scope.height !== undefined) {
+                                        chart.width(scope.width).height(scope.height);
+                                    }
+                                    chart.margin(scope.margin)
                                         .tooltips(attrs.tooltips === undefined ? false : (attrs.tooltips  === 'true'))
                                         .noData(attrs.nodata === undefined ? 'No Data Available.' : scope.nodata)
                                         .showLabels(attrs.showlabels === undefined ? false : (attrs.showlabels === 'true'))
                                         .labelThreshold(attrs.labelthreshold === undefined ? 0.02 : attrs.labelthreshold)
                                         .labelType(attrs.labeltype === undefined ? 'key' : attrs.labeltype)
-                                        .pieLabelsOutside(attrs.pielabelsoutside === undefined ? true : (attrs.pielabelsoutside === 'true'))
                                         .valueFormat(attrs.valueformat === undefined ? d3.format(',.2f') : attrs.valueformat)
                                         .showLegend(attrs.showlegend === undefined ? false : (attrs.showlegend === 'true'))
-                                        .description(attrs.description === undefined ?  function(d) { return d.description; } : scope.description())
                                         .color(attrs.color === undefined ? nv.utils.defaultColor()  : scope.color())
-                                        .donutLabelsOutside(attrs.donutlabelsoutside === undefined ? false : (attrs.donutlabelsoutside === 'true'))
                                         .donut(attrs.donut === undefined ? false : (attrs.donut === 'true'))
                                         .donutRatio(attrs.donutratio === undefined ? 0.5 : (attrs.donutratio));
 


### PR DESCRIPTION
As of 1.8.1 the deleted pie chart properties are no longer present in nvd3.js

Additionally, charts work just fine without a specified height and width - they just calculate the width from their container.

However, the code here was assuming a height and width were provided, and as a result "viewbox='0 0 undefined undefined'" was appearing.
